### PR TITLE
Remove Swatinem/rust-cache from workflows that only setup nightly

### DIFF
--- a/rustdoc/action.yaml
+++ b/rustdoc/action.yaml
@@ -29,6 +29,3 @@ runs:
     - name: Show cargo version
       shell: bash
       run: cargo version --verbose
-
-    - name: Setup Rust caching
-      uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
These caches are too short lived to be useful.