### PR TITLE
Only enable Rust artifact caching when a `Cargo.lock` is present

### DIFF
--- a/build-and-test/action.yaml
+++ b/build-and-test/action.yaml
@@ -45,5 +45,16 @@ runs:
       shell: bash
       run: cargo +${{ inputs.toolchain }} version --verbose
 
+    - name: Check if Cargo.lock is present
+      shell: bash
+      id: lockfile
+      run: |
+        if [[ -f Cargo.lock ]]; then
+          echo "present=true" >> $GITHUB_OUTPUT
+        else
+          echo "present=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Setup Rust caching
       uses: Swatinem/rust-cache@v1
+      if: steps.lockfile.outputs.present == 'true'

--- a/check-minimal-versions/action.yaml
+++ b/check-minimal-versions/action.yaml
@@ -2,6 +2,12 @@
 name: "Minimal Versions Toolchain"
 description: "Setup stable and nightly Rust toolchains for running cargo check with -Zminimal-versions"
 
+inputs:
+  toolchain:
+    description: "Rustup toolchain"
+    required: true
+    default: "stable"
+
 runs:
   using: "composite"
   steps:

--- a/check-minimal-versions/action.yaml
+++ b/check-minimal-versions/action.yaml
@@ -62,5 +62,16 @@ runs:
       shell: bash
       run: cargo +nightly fmt --version --verbose
 
+    - name: Check if Cargo.lock is present
+      shell: bash
+      id: lockfile
+      run: |
+        if [[ -f Cargo.lock ]]; then
+          echo "present=true" >> $GITHUB_OUTPUT
+        else
+          echo "present=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Setup Rust caching
       uses: Swatinem/rust-cache@v1
+      if: steps.lockfile.outputs.present == 'true'

--- a/lint-and-format/action.yaml
+++ b/lint-and-format/action.yaml
@@ -68,5 +68,16 @@ runs:
       shell: bash
       run: cargo +nightly fmt --version --verbose
 
+    - name: Check if Cargo.lock is present
+      shell: bash
+      id: lockfile
+      run: |
+        if [[ -f Cargo.lock ]]; then
+          echo "present=true" >> $GITHUB_OUTPUT
+        else
+          echo "present=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Setup Rust caching
       uses: Swatinem/rust-cache@v1
+      if: steps.lockfile.outputs.present == 'true'


### PR DESCRIPTION
Swatinem/rust-cache documents that the action is most effective when a lockfile is present, so only activate it if we find a `Cargo.lock` in the repository root.

This helps make sure we don't needlessly consume cache resources on GitHub.