### PR TITLE
Pass the given toolchain to 'rustup target add'

### DIFF
--- a/build-and-test/action.yaml
+++ b/build-and-test/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: Install additional target
       shell: bash
       if: inputs.target != ''
-      run: rustup target add "${{ inputs.target }}"
+      run: rustup target add --toolchain "${{ inputs.toolchain }}" "${{ inputs.target }}"
 
     - name: Set default toolchain to ${{ inputs.toolchain }}
       shell: bash


### PR DESCRIPTION
Fixed some breakage when migrating the nightly builder to these actions: https://github.com/artichoke/nightly/actions/runs/3466310825/jobs/5790008114.