### PR TITLE
Address zizmor security issues in GitHub Actions setup

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,6 +9,7 @@ name: Audit
       - trunk
   schedule:
     - cron: "0 0 * * TUE"
+permissions: {}
 jobs:
   ruby:
     name: Audit Ruby Dependencies
@@ -17,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0

--- a/.github/workflows/block-merge.yaml
+++ b/.github/workflows/block-merge.yaml
@@ -3,10 +3,14 @@ name: Merge
 "on":
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+permissions: {}
 jobs:
   labels:
     name: Labels
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
 
     steps:
       - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ name: CI
       - trunk
   schedule:
     - cron: "0 0 * * TUE"
+permissions: {}
 jobs:
   test-setup-audit-toolchain:
     name: Test setup audit toolchain action
@@ -18,6 +19,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup stable audit toolchain
         uses: ./setup-rust-action/audit
@@ -34,6 +36,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup nightly build and test toolchain
         uses: ./setup-rust-action/build-and-test
@@ -89,6 +92,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup stable build and test toolchain
         uses: ./setup-rust-action/check-minimal-versions
@@ -134,6 +138,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup stable audit toolchain
         uses: ./setup-rust-action/code-coverage
@@ -150,6 +155,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup stable build and test toolchain
         uses: ./setup-rust-action/lint-and-format
@@ -231,6 +237,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup stable audit toolchain
         uses: ./setup-rust-action/miri
@@ -247,6 +254,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: setup-rust-action
+          persist-credentials: false
 
       - name: Setup nightly rustdoc toolchain
         uses: ./setup-rust-action/rustdoc
@@ -261,6 +269,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
@@ -277,6 +287,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -15,12 +15,18 @@
   schedule:
     - cron: "0 0 * * TUE"
 name: Create Repository Labels
+permissions: {}
 jobs:
   labels:
     name: Synchronize repository labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Sync GitHub Issue Labels
         uses: crazy-max/ghaction-github-labeler@b54af0c25861143e7c8813d7cbbf46d2c341680c # v5.1.0

--- a/audit/action.yaml
+++ b/audit/action.yaml
@@ -7,31 +7,49 @@ inputs:
     description: "Rustup toolchain"
     required: true
     default: "stable"
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain override
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose

--- a/audit/action.yaml
+++ b/audit/action.yaml
@@ -14,24 +14,28 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
     - name: Set default toolchain override
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -45,11 +49,15 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose

--- a/build-and-test/action.yaml
+++ b/build-and-test/action.yaml
@@ -18,19 +18,20 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
-    TARGET: ${{ inputs.target }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
@@ -38,12 +39,17 @@ runs:
       shell: bash
       working-directory: ${{ inputs.override-dir }}
       if: inputs.target != ''
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
+        TARGET: ${{ inputs.target }}
       run: |
         rustup target add --toolchain "$TOOLCHAIN" "$TARGET"
 
     - name: Set default toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -57,12 +63,16 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose
 

--- a/build-and-test/action.yaml
+++ b/build-and-test/action.yaml
@@ -11,48 +11,70 @@ inputs:
     description: "Target triple"
     required: false
     default: ""
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
+    TARGET: ${{ inputs.target }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
     - name: Install additional target
       shell: bash
+      working-directory: ${{ inputs.override-dir }}
       if: inputs.target != ''
-      run: rustup target add --toolchain "${{ inputs.toolchain }}" "${{ inputs.target }}"
+      run: |
+        rustup target add --toolchain "$TOOLCHAIN" "$TARGET"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose
 
     - name: Check if Cargo.lock is present
       shell: bash
+      working-directory: ${{ inputs.override-dir }}
       id: lockfile
       run: |
         if [[ -f Cargo.lock ]]; then
-          echo "present=true" >> $GITHUB_OUTPUT
+          echo "present=true" >> "$GITHUB_OUTPUT"
         else
-          echo "present=false" >> $GITHUB_OUTPUT
+          echo "present=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Rust caching

--- a/check-minimal-versions/action.yaml
+++ b/check-minimal-versions/action.yaml
@@ -14,24 +14,28 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
     - name: Set default toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -45,12 +49,16 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose
 

--- a/check-minimal-versions/action.yaml
+++ b/check-minimal-versions/action.yaml
@@ -7,75 +7,86 @@ inputs:
     description: "Rustup toolchain"
     required: true
     default: "stable"
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --component clippy --component rustfmt
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
-
-    - name: Show ${{ inputs.toolchain }} clippy version
-      shell: bash
-      run: cargo +${{ inputs.toolchain }} clippy --version --verbose
-
-    - name: Show ${{ inputs.toolchain }} rustfmt version
-      shell: bash
-      run: cargo +${{ inputs.toolchain }} fmt --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose
 
     - name: Install nightly toolchain
       shell: bash
-      run: rustup toolchain install nightly --profile minimal --component clippy --component rustfmt
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install nightly --profile minimal
 
     - name: Update nightly toolchain
       shell: bash
-      run: rustup update nightly
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update nightly
 
     - name: Show nightly rustc version
       shell: bash
-      run: rustc +nightly -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +nightly -Vv
 
     - name: Show nightly cargo version
       shell: bash
-      run: cargo +nightly version --verbose
-
-    - name: Show nightly clippy version
-      shell: bash
-      run: cargo +nightly clippy --version --verbose
-
-    - name: Show nightly rustfmt version
-      shell: bash
-      run: cargo +nightly fmt --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +nightly version --verbose
 
     - name: Check if Cargo.lock is present
       shell: bash
+      working-directory: ${{ inputs.override-dir }}
       id: lockfile
       run: |
         if [[ -f Cargo.lock ]]; then
-          echo "present=true" >> $GITHUB_OUTPUT
+          echo "present=true" >> "$GITHUB_OUTPUT"
         else
-          echo "present=false" >> $GITHUB_OUTPUT
+          echo "present=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Rust caching

--- a/code-coverage/action.yaml
+++ b/code-coverage/action.yaml
@@ -7,31 +7,49 @@ inputs:
     description: "Rustup toolchain"
     required: true
     default: "nightly"
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --component llvm-tools-preview
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal --component clippy --component rustfmt
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose

--- a/code-coverage/action.yaml
+++ b/code-coverage/action.yaml
@@ -14,24 +14,28 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal --component clippy --component rustfmt
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
     - name: Set default toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -45,11 +49,15 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose

--- a/lint-and-format/action.yaml
+++ b/lint-and-format/action.yaml
@@ -7,75 +7,110 @@ inputs:
     description: "Rustup toolchain"
     required: true
     default: "stable"
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --component clippy --component rustfmt
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal --component clippy --component rustfmt
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose
 
-    - name: Show ${{ inputs.toolchain }} clippy version
+    - name: Show clippy version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} clippy --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" clippy --version --verbose
 
-    - name: Show ${{ inputs.toolchain }} rustfmt version
+    - name: Show rustfmt version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} fmt --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" fmt --version --verbose
 
     - name: Install nightly toolchain
       shell: bash
-      run: rustup toolchain install nightly --profile minimal --component clippy --component rustfmt
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install nightly --profile minimal --component clippy --component rustfmt
 
     - name: Update nightly toolchain
       shell: bash
-      run: rustup update nightly
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update nightly
 
     - name: Show nightly rustc version
       shell: bash
-      run: rustc +nightly -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +nightly -Vv
 
     - name: Show nightly cargo version
       shell: bash
-      run: cargo +nightly version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +nightly version --verbose
 
     - name: Show nightly clippy version
       shell: bash
-      run: cargo +nightly clippy --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +nightly clippy --version --verbose
 
     - name: Show nightly rustfmt version
       shell: bash
-      run: cargo +nightly fmt --version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +nightly fmt --version --verbose
 
     - name: Check if Cargo.lock is present
       shell: bash
+      working-directory: ${{ inputs.override-dir }}
       id: lockfile
       run: |
         if [[ -f Cargo.lock ]]; then
-          echo "present=true" >> $GITHUB_OUTPUT
+          echo "present=true" >> "$GITHUB_OUTPUT"
         else
-          echo "present=false" >> $GITHUB_OUTPUT
+          echo "present=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Rust caching

--- a/lint-and-format/action.yaml
+++ b/lint-and-format/action.yaml
@@ -14,24 +14,28 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal --component clippy --component rustfmt
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
     - name: Set default toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -45,24 +49,32 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose
 
     - name: Show clippy version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" clippy --version --verbose
 
     - name: Show rustfmt version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" fmt --version --verbose
 

--- a/miri/action.yaml
+++ b/miri/action.yaml
@@ -14,24 +14,28 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
     - name: Install toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup toolchain install "$TOOLCHAIN" --profile minimal --component miri --component rust-src
 
     - name: Update toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustup update "$TOOLCHAIN"
 
     - name: Set default toolchain
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         # https://rust-lang.github.io/rustup/overrides.html
         rustup override set "$TOOLCHAIN"
@@ -45,16 +49,22 @@ runs:
     - name: Show rustc version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         rustc +"$TOOLCHAIN" -Vv
 
     - name: Show cargo version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         cargo +"$TOOLCHAIN" version --verbose
 
     - name: Show miri version
       shell: bash
       working-directory: ${{ inputs.override-dir }}
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
       run: cargo +"$TOOLCHAIN" miri --version

--- a/miri/action.yaml
+++ b/miri/action.yaml
@@ -7,35 +7,54 @@ inputs:
     description: "Rustup toolchain"
     required: true
     default: "nightly"
+  override-dir:
+    description: "Directory to set the rustup override for"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
+  env:
+    TOOLCHAIN: ${{ inputs.toolchain }}
   steps:
-    - name: Install ${{ inputs.toolchain }} toolchain
+    - name: Install toolchain
       shell: bash
-      run: rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --component miri --component rust-src
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup toolchain install "$TOOLCHAIN" --profile minimal --component miri --component rust-src
 
-    - name: Update ${{ inputs.toolchain }} toolchain
+    - name: Update toolchain
       shell: bash
-      run: rustup update "${{ inputs.toolchain }}"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup update "$TOOLCHAIN"
 
-    - name: Set default toolchain to ${{ inputs.toolchain }}
+    - name: Set default toolchain
       shell: bash
-      # https://rust-lang.github.io/rustup/overrides.html
-      run: echo 'RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}' >> "$GITHUB_ENV"
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        # https://rust-lang.github.io/rustup/overrides.html
+        rustup override set "$TOOLCHAIN"
 
     - name: Show rustup version
       shell: bash
-      run: rustup -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustup -Vv
 
-    - name: Show ${{ inputs.toolchain }} rustc version
+    - name: Show rustc version
       shell: bash
-      run: rustc +${{ inputs.toolchain }} -Vv
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        rustc +"$TOOLCHAIN" -Vv
 
-    - name: Show ${{ inputs.toolchain }} cargo version
+    - name: Show cargo version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} version --verbose
+      working-directory: ${{ inputs.override-dir }}
+      run: |
+        cargo +"$TOOLCHAIN" version --verbose
 
-    - name: Show ${{ inputs.toolchain }} miri version
+    - name: Show miri version
       shell: bash
-      run: cargo +${{ inputs.toolchain }} miri --version
+      working-directory: ${{ inputs.override-dir }}
+      run: cargo +"$TOOLCHAIN" miri --version


### PR DESCRIPTION
There's a slight breaking change in here where the check-minimal-versions action no longer installs clippy and rustup, but these should be unused by callers.